### PR TITLE
onnxmltools 1.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - python
     - numpy
     - onnx
-    - packaging
 
 test:
   imports:
@@ -32,6 +31,8 @@ test:
     - pip check
   requires:
     - pip
+    - packaging
+    - onnxconverter-common
 
 about:
   home: https://learn.microsoft.com/en-us/windows/ai/windows-ml/onnxmltools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - python
     - numpy
     - onnx
+    - packaging
+    - onnxconverter-common
 
 test:
   imports:
@@ -31,8 +33,6 @@ test:
     - pip check
   requires:
     - pip
-    - packaging
-    - onnxconverter-common
 
 about:
   home: https://learn.microsoft.com/en-us/windows/ai/windows-ml/onnxmltools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - python
     - numpy
     - onnx
-    - skl2onnx
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,9 @@ requirements:
     - wheel
   run:
     - python
-    - numpy 
-    - onnx 
-    - skl2onnx 
+    - numpy
+    - onnx
+    - skl2onnx
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - python
     - numpy
     - onnx
+    - packaging
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "onnxmltools" %}
-{% set version = "1.11.2" %}
+{% set version = "1.12.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  - url: https://github.com/onnx/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 0db032ac4625e35da757465d6f01bc3f4ce3d6e112d7f50c1a57c8816695eec4
+  - url: https://github.com/onnx/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+    sha256: 740852771744323dcd3fa60064dbc54dd0ee807c58384b06940497ffbf67caf8
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4677](https://anaconda.atlassian.net/browse/PKG-4677)
- [Upstream repository](https://github.com/onnx/onnxmltools/tree/1.12.0)
- [Upstream changelog/diff](https://github.com/onnx/onnxmltools/blob/1.12.0/CHANGELOGS.md)

### Explanation of changes:

- Update version
- Update source URL
- Remove python version skip since `setup.py` has no required version limit
- Update dependencies

[PKG-4677]: https://anaconda.atlassian.net/browse/PKG-4677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ