### PR TITLE
onnxmltools 1.16.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "onnxmltools" %}
-{% set version = "1.12.0" %}
+{% set version = "1.16.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,12 @@ package:
 
 source:
   - url: https://github.com/onnx/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-    sha256: 740852771744323dcd3fa60064dbc54dd0ee807c58384b06940497ffbf67caf8
+    sha256: abd9e957ef97a85aa4920bee2d6f2ad46cd42e067a9971469190650641404765
 
 build:
   number: 0
+  # skl2onnx (upstream hard dep) is not yet built for py3.14 on pkgs/main
+  skip: true  # [py>313]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -22,9 +24,10 @@ requirements:
   run:
     - python
     - numpy
-    - onnx
+    - onnx >=1.8.1
     - packaging
-    - onnxconverter-common
+    - protobuf
+    - skl2onnx >=1.4.9
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   host:
     - pip
     - python
-    - setuptools
+    - setuptools >=61
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,6 @@ source:
 
 build:
   number: 0
-  # skl2onnx (upstream hard dep) is not yet built for py3.14 on pkgs/main
-  skip: true  # [py>313]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:


### PR DESCRIPTION
## onnxmltools 1.16.0

**Destination channel:** defaults

### Links
- [PKG-13882](https://anaconda.atlassian.net/browse/PKG-13882)
- [GitHub release 1.16.0](https://github.com/onnx/onnxmltools/releases/tag/1.16.0)
- [Changelog](https://github.com/onnx/onnxmltools/blob/1.16.0/CHANGELOGS.md)

### Explanation of changes
- Updated `onnxmltools` from 1.12.0 to 1.16.0.
- Added `skip: true  # [py>313]` — `skl2onnx` (now an upstream hard dep) is not yet built for py3.14 on pkgs/main.
- Run-dep adjustments to match upstream `pyproject.toml`:
  - Removed `onnxconverter-common` — upstream dropped this dependency in 1.14.0 (CHANGELOGS.md: "Removes dependency on onnxconveter-common").
  - Added `skl2onnx >=1.4.9` — listed as a hard install dep in upstream `pyproject.toml`; required for `pip check`.
  - Added `protobuf` — listed in upstream `pyproject.toml`.
  - Bumped `onnx` to `>=1.8.1` to match upstream.
  - Kept `packaging` — used eagerly in `onnxmltools/convert/main.py`.

[PKG-13882]: https://anaconda.atlassian.net/browse/PKG-13882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ